### PR TITLE
Prepare UI for new exchanges

### DIFF
--- a/public/images/switch-vertical.svg
+++ b/public/images/switch-vertical.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+</svg>

--- a/resources/assets/js/components/modals/DeleteExchangeModal.vue
+++ b/resources/assets/js/components/modals/DeleteExchangeModal.vue
@@ -1,8 +1,8 @@
 <template>
     <b-modal ref="modal" :title="`Delete exchange request on ${this.course}`" size="lg">
         Are you sure to delete the exchange request to <strong>{{ this.toShift }}</strong> on <strong>{{ this.course }}</strong>?
-        <br>
-        This exchange was proposed to <strong>{{ this.student.name }} ({{ this.student.number }})</strong>.
+        <!-- <br>
+        This exchange was proposed to <strong>{{ this.student.name }} ({{ this.student.number }})</strong>. -->
         <form slot="modal-footer" :action="`/exchanges/${ this.id }`" method="post">
             <csrf-field></csrf-field>
             <input type="hidden" name="_method" value="DELETE">

--- a/resources/assets/sass/_table.sass
+++ b/resources/assets/sass/_table.sass
@@ -9,3 +9,7 @@
 
     .table-active
         background-color: rgba(247, 247, 249, 0.6)
+
+    .exchange-icon
+        width: 0px
+        padding-right: 0px

--- a/resources/assets/sass/_table.sass
+++ b/resources/assets/sass/_table.sass
@@ -11,5 +11,5 @@
         background-color: rgba(247, 247, 249, 0.6)
 
     .exchange-icon
-        width: 0px
+        width: 44px
         padding-right: 0px

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -8,11 +8,11 @@
     @endif
 
     {{-- Exchanges waiting confirmation --}}
-    @includeWhen(
+    {{-- @includeWhen(
         $settings->withinExchangePeriod(),
         'exchanges.dashboard.proposed.index',
         ['exchanges' => $proposedExchanges]
-    )
+    ) --}}
 
     {{-- Pending requested exchanges --}}
     @includeWhen(

--- a/resources/views/exchanges/dashboard/requested/show.blade.php
+++ b/resources/views/exchanges/dashboard/requested/show.blade.php
@@ -1,11 +1,12 @@
 <tr>
+    <td class="exchange-icon"><img alt="switch" height="24" src="{{ asset('images/switch-vertical.svg') }}"></td>
     <td>
         {{ $exchange->course()->name }}
         <br>
         <small class="text-muted">
             From <strong>{{ $exchange->fromShift()->tag }}</strong>
             to <strong>{{ $exchange->toShift()->tag }}</strong>
-            requested to <strong>{{ $exchange->toStudent()->user->name }} ({{ $exchange->toStudent()->student_number }})</strong>
+            {{-- requested to <strong>{{ $exchange->toStudent()->user->name }} ({{ $exchange->toStudent()->student_number }})</strong> --}}
         </small>
     </td>
     <td class="text-right">

--- a/resources/views/exchanges/dashboard/requested/show.blade.php
+++ b/resources/views/exchanges/dashboard/requested/show.blade.php
@@ -1,5 +1,5 @@
 <tr>
-    <td class="exchange-icon"><img alt="switch" height="24" src="{{ asset('images/switch-vertical.svg') }}"></td>
+    <td class="exchange-icon d-none d-sm-table-cell"><img alt="switch" height="24" src="{{ asset('images/switch-vertical.svg') }}"></td>
     <td>
         {{ $exchange->course()->name }}
         <br>


### PR DESCRIPTION
Slightly changed the UI to prepare it for the new automatic exchanges system.

**Notes:** In `resources/views/dashboard.blade.php`, `$requestedExchanges` will need to be changed to shifts in order to use the new exchange format. `$proposedExchanges` were commented out because there is not a need anymore for two types of exchanges (there are no incoming or outgoing exchanges now, only automatic ones).